### PR TITLE
Habilita o objeto BoletoCaixaSigcb

### DIFF
--- a/pyboleto/bank/__init__.py
+++ b/pyboleto/bank/__init__.py
@@ -4,7 +4,7 @@ BANCOS_IMPLEMENTADOS = {
     '001': 'bancodobrasil.BoletoBB',
     '041': 'banrisul.BoletoBanrisul',
     '237': 'bradesco.BoletoBradesco',
-    '104': 'caixa.BoletoCaixa',
+    '104': 'caixa_sigcb.BoletoCaixaSigcb',
     '399': 'hsbc.BoletoHsbc',
     '341': 'itau.BoletoItau',
     '356': 'real.BoletoReal',

--- a/pyboleto/bank/caixa_sigcb.py
+++ b/pyboleto/bank/caixa_sigcb.py
@@ -9,7 +9,7 @@ class BoletoCaixaSigcb(BoletoData):
     '''
 
     agencia_cedente = CustomProperty('agencia_cedente', 4)
-    conta_cedente = CustomProperty('conta_cedente', 6)
+    convenio = CustomProperty('convenio', 6)
     nosso_numero = CustomProperty('nosso_numero', 17)
 
     def __init__(self):
@@ -23,8 +23,8 @@ class BoletoCaixaSigcb(BoletoData):
     @property
     def campo_livre(self):  # 24 digits
         content = "%6s%1s%3s%1s%3s%1s%9s" % (
-            self.conta_cedente.split('-')[0],
-            self.modulo11(self.conta_cedente.split('-')[0]),
+            self.convenio.split('-')[0],
+            self.modulo11(self.convenio.split('-')[0]),
             self.nosso_numero[2:5],
             self.nosso_numero[0:1],
             self.nosso_numero[5:8],


### PR DESCRIPTION
Os campos livres do código de barra do boleto da Caixa Econômica estavam sendo gerados numa rotina antiga, contida no objetivo BoletoCaixa. Setando o objetivo BoletoCaixaSigcb conseguimos solucionar o problema