### PR TITLE
ajuste para abrir o template com codificação utf-8 e a logo como binário

### DIFF
--- a/pyboleto/html.py
+++ b/pyboleto/html.py
@@ -7,7 +7,7 @@
 
     :copyright: © 2012 by Artur Felipe de Sousa
     :license: BSD, see LICENSE for more details.
-
+    
 """
 import os
 import string
@@ -74,7 +74,7 @@ class BoletoHTML(object):
     def _load_template(self, template):
         pyboleto_dir = os.path.dirname(os.path.abspath(__file__))
         template_path = os.path.join(pyboleto_dir, 'templates', template)
-        with open(template_path, 'r') as tpl:
+        with open(template_path, 'r', encoding='utf-8') as tpl:
             template_content = tpl.read()
         return template_content
 


### PR DESCRIPTION
precisei fazer isso para não ocorrer erro ao abrir o template e a logo, usando boleto santander.
O erro também ocorreu com o boleto da caixa, e acredito que ocorre com todos.
Mas talvez somente no Python 3, no 2 eu não testei e não sei se essas alterações podem trazer problemas.