### PR TITLE
Inclusão de envio de valores no campo linha digitável e código de barras

### DIFF
--- a/pyboleto/data.py
+++ b/pyboleto/data.py
@@ -41,6 +41,7 @@ class CustomProperty(object):
     :type length: integer
 
     """
+
     def __init__(self, name, length):
         self.name = name
         self.length = length
@@ -117,6 +118,8 @@ class BoletoData(object):
 
     **Parâmetros não obrigatórios**:
 
+    :param codigo_barras: Se o codigo de barras for informado, não calcula
+    :param linha_digitavel_ext: Se a linha digitável for informada (com espaços), não calcula
     :param quantidade:
     :param especie: Nunca precisa mudar essa opção *(default: 'R$')*
     :param especie_documento:
@@ -161,6 +164,8 @@ class BoletoData(object):
         self.sacado_endereco = kwargs.pop('sacado_endereco', "")
         self.sacado_bairro = kwargs.pop('sacado_bairro', "")
         self.sacado_cep = kwargs.pop('sacado_cep', "")
+        self.codigo_barras = kwargs.pop('codigo_barras', None)
+        self.linha_digitavel_ext = kwargs.pop('linha_digitavel_ext', None)
         if kwargs:
             raise TypeError("Paramêtro(s) desconhecido: %r" % (kwargs, ))
         self._cedente_endereco = None
@@ -186,6 +191,9 @@ class BoletoData(object):
         20 a 44  25  Campo Livre definido por cada banco
         Total    44
         """
+
+        if not self.codigo_barras:
+            return self.codigo_barras
 
         for attr, length, data_type in [
                 ('codigo_banco', 3, str),
@@ -435,6 +443,10 @@ class BoletoData(object):
         Esta é a linha que o cliente pode utilizar para digitar se o código
         de barras não estiver legível.
         """
+
+        if not self.linha_digitavel_ext:
+            return self.linha_digitavel_ext
+
         linha = self.barcode
         if not linha:
             raise BoletoException("Boleto doesn't have a barcode")

--- a/pyboleto/data.py
+++ b/pyboleto/data.py
@@ -164,8 +164,8 @@ class BoletoData(object):
         self.sacado_endereco = kwargs.pop('sacado_endereco', "")
         self.sacado_bairro = kwargs.pop('sacado_bairro', "")
         self.sacado_cep = kwargs.pop('sacado_cep', "")
-        self.codigo_barras = kwargs.pop('codigo_barras', None)
-        self.linha_digitavel_ext = kwargs.pop('linha_digitavel_ext', None)
+        self.codigo_barras = kwargs.pop('codigo_barras', "")
+        self.linha_digitavel_ext = kwargs.pop('linha_digitavel_ext', "")
         if kwargs:
             raise TypeError("Paramêtro(s) desconhecido: %r" % (kwargs, ))
         self._cedente_endereco = None
@@ -192,7 +192,7 @@ class BoletoData(object):
         Total    44
         """
 
-        if not self.codigo_barras:
+        if self.codigo_barras != "":
             return self.codigo_barras
 
         for attr, length, data_type in [
@@ -444,7 +444,7 @@ class BoletoData(object):
         de barras não estiver legível.
         """
 
-        if not self.linha_digitavel_ext:
+        if self.linha_digitavel_ext != "":
             return self.linha_digitavel_ext
 
         linha = self.barcode

--- a/pyboleto/pdf.py
+++ b/pyboleto/pdf.py
@@ -780,7 +780,7 @@ class BoletoPDF(object):
         d = self.drawBoletoCarne(boletoDados1, y)
         y += d[1] + 6 * mm
         # self._drawHorizontalCorteLine(0, y, d[0])
-        y += 7 * mm
+        # y += 7 * mm
         if boletoDados2:
             self.drawBoletoCarne(boletoDados2, y)
 

--- a/tests/test_banco_itau_com_dados_calculados.py
+++ b/tests/test_banco_itau_com_dados_calculados.py
@@ -7,7 +7,7 @@ from pyboleto.bank.itau import BoletoItau
 from .testutils import BoletoTestCase
 
 
-class TestBancoItau(BoletoTestCase):
+class TestBancoItauComDadosCalculados(unittest.TestCase):
     def setUp(self):
         self.dados = []
         for i in range(3):
@@ -51,7 +51,8 @@ class TestBancoItau(BoletoTestCase):
         self.assertEqual(self.dados[0].dv_agencia_conta_cedente, 0)
 
 
-suite = unittest.TestLoader().loadTestsFromTestCase(TestBancoItau)
+suite = unittest.TestLoader().loadTestsFromTestCase(
+    TestBancoItauComDadosCalculados)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_banco_itau_com_linha_e_barcode.py
+++ b/tests/test_banco_itau_com_linha_e_barcode.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+import unittest
+import datetime
+
+from pyboleto.bank.itau import BoletoItau
+
+from .testutils import BoletoTestCase
+
+
+class TestBancoItau(BoletoTestCase):
+    def setUp(self):
+        self.dados = []
+        for i in range(3):
+            d = BoletoItau()
+            d.carteira = '109'
+            d.agencia_cedente = '0293'
+            d.conta_cedente = '01328'
+            d.conta_cedente_dv = '1'
+            d.data_vencimento = datetime.date(2009, 10, 19)
+            d.data_documento = datetime.date(2009, 10, 19)
+            d.data_processamento = datetime.date(2009, 10, 19)
+            d.valor_documento = 29.80
+            d.nosso_numero = str(157 + i)
+            d.numero_documento = str(456 + i)
+            d.linha_digitavel_ext = "34191.09008 00015.710296 30132.810000 4 43950000002888"
+            d.codigo_barras = "34194439500000029801090000015710293013281999"
+            self.dados.append(d)
+
+    def test_linha_digitavel(self):
+        self.assertEqual(
+            self.dados[0].linha_digitavel,
+            '34191.09008 00015.710296 30132.810000 4 43950000002888'
+        )
+
+    def test_codigo_de_barras(self):
+        self.assertEqual(
+            self.dados[0].barcode,
+            '34194439500000029801090000015710293013281999'
+        )
+
+    def test_agencia(self):
+        self.assertEqual(self.dados[0].agencia_cedente, '0293')
+
+    def test_conta(self):
+        self.assertEqual(self.dados[0].conta_cedente, '01328')
+
+    def test_dv_nosso_numero(self):
+        self.assertEqual(self.dados[0].dv_nosso_numero, 1)
+
+    def test_dv_agencia_conta_cedente(self):
+        self.assertEqual(self.dados[0].dv_agencia_conta_cedente, 0)
+
+
+suite = unittest.TestLoader().loadTestsFromTestCase(TestBancoItau)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Com a implantação do registro Registro Online por grande parte dos bancos brasileiros, muitos deles estão retornando informações que antes eram calculadas pela instituição financeira que realizava o registro. 
Portanto, decidimos utilizar os campos código de barras e linha digitável dos bancos que devolvem estes valores no registro de boleto. Caso essas informações não sejam enviadas no BoletoData, ele irá calcular normalmente como já é feito.

Além disso fizemos uma correção para #18, pois o carnê duplo do Itaú também estava com esse problema.